### PR TITLE
Apply all entity type configs in assembly

### DIFF
--- a/server/Data/EquipmentBookingContext.cs
+++ b/server/Data/EquipmentBookingContext.cs
@@ -25,6 +25,7 @@ public class EquipmentBookingContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
+        // Applies configuration from all IEntityTypeConfiguration<TEntity> instances that are defined in provided assembly. (Microsoft docs)
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(EquipmentBookingContext).Assembly);
     }
 }

--- a/server/Data/EquipmentBookingContext.cs
+++ b/server/Data/EquipmentBookingContext.cs
@@ -25,7 +25,6 @@ public class EquipmentBookingContext : DbContext
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        new UserEntityTypeConfiguration().Configure(modelBuilder.Entity<User>());
-        new BookingEntityTypeConfiguration().Configure(modelBuilder.Entity<Booking>());
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(EquipmentBookingContext).Assembly);
     }
 }


### PR DESCRIPTION
The idea is to apply all implementations of `IEntityTypeConfig<T>` in the application with a single line of code (as per this Microsoft [article](https://learn.microsoft.com/en-us/ef/core/modeling/#applying-all-configurations-in-an-assembly)). That is done now. 